### PR TITLE
Use Java 21 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,4 +27,4 @@ jobs:
     displayName: Build in build-wrapper
   - task: SonarQubeAnalyze@5
     inputs:
-      jdkversion: 'JAVA_HOME_17_X64'
+      jdkversion: 'JAVA_HOME_21_X64'


### PR DESCRIPTION
## Summary
- run the Sonar analysis step with Java 21

## Validation
- Parsed the changed YAML with Python
- git diff --check

The current Sonar scanner no longer supports Java 17.

## Fork PR CI note

The Azure pipeline check is expected to fail for this PR because it originates from a fork. Azure DevOps skips `SonarQubePrepare`, which references the protected SonarQube service endpoint, so `SonarQubeAnalyze` subsequently reports that its variables are missing. After merge, the `main` build can access the service connection and should validate the Java 21 change successfully.